### PR TITLE
The TLS certificate for https://v1-18.docs.kubernetes.io/docs/home has expired

### DIFF
--- a/_posts/2021-08-31-Kubernetes.md
+++ b/_posts/2021-08-31-Kubernetes.md
@@ -17,9 +17,6 @@ project:
 
 supported_releases:
   - release:
-    version: "v1.18"
-    url: "https://v1-18.docs.kubernetes.io/docs/home"
-  - release:
     version: "v1.19"
     url: "https://v1-19.docs.kubernetes.io/docs/home"
   - release:
@@ -28,6 +25,9 @@ supported_releases:
   - release:
     version: "v1.21"
     url: "https://v1-21.docs.kubernetes.io/docs/home"
+  - release:
+    version: "v1.22"
+    url: "https://v1-22.docs.kubernetes.io/docs/home"
   - release:
     version: "Latest"
     url: "https://kubernetes.io/docs/home/"


### PR DESCRIPTION
Remove 1.18 and add 1.22

See https://github.com/Linaro/ecosystemlandscape/runs/4525631246?check_suite_focus=true