### PR TITLE
Adding GA4 Analytics Property via correct Google Tag Manager

### DIFF
--- a/_config-production.yml
+++ b/_config-production.yml
@@ -11,4 +11,4 @@ production: true
 # Google Analytics
 google_analytics:
   enabled: true
-  code: GTM-TKVP3S4
+  code: GTM-MK2VQ73

--- a/_config.yml
+++ b/_config.yml
@@ -74,7 +74,7 @@ http2_resources:
     href: /assets/fonts/lato/Lato-regular.woff2
 google_analytics:
   enabled: false
-  code: GTM-TKVP3S4
+  code: GTM-XXXXXX
   cookies:
     necessary:
       - name: cookieControl


### PR DESCRIPTION
Adding Google Tag Manager with the new GA4 analytics property since the previous property is reaching end-of-life